### PR TITLE
Preliminary implementation of an installer

### DIFF
--- a/lib/Pakket/CLI/Command/install.pm
+++ b/lib/Pakket/CLI/Command/install.pm
@@ -1,0 +1,54 @@
+package Pakket::CLI::Command::install;
+# ABSTRACT: The pakket install command
+
+use strict;
+use warnings;
+use Pakket::CLI -command;
+use Pakket::Installer;
+use Path::Tiny qw< path >;
+
+sub abstract    { 'Install a package' }
+sub description { 'Install a package' }
+
+sub opt_spec {
+    return (
+        [ 'to=s',       'directory to install the package in'  ],
+        [ 'verbose|v+', 'verbose output (can be provided multiple times)' ],
+    );
+}
+
+sub validate_args {
+    my ( $self, $opt, $args ) = @_;
+
+    defined $opt->{'to'}
+        and $self->{'installer'}{'base_dir'} = $opt->{'to'};
+
+    @{$args} == 0
+        and $self->usage_error('Must provide package to install');
+
+    my $package = $args->[0];
+
+    # FIXME: support more options here :)
+    # (validation for URLs, at least for now)
+    -f $package
+        or $self->usage_error('Currently only a bundle file is supported');
+
+    $self->{'bundle_file'} = $package;
+}
+
+sub execute {
+    my $self      = shift;
+    my $installer = Pakket::Installer->new(
+        map( +(
+            defined $self->{'installer'}{$_}
+                ? ( $_ => $self->{'installer'}{$_} )
+                : ()
+        ), qw< base_dir > ),
+    );
+
+    $installer->install_file( $self->{'bundle_file'} );
+}
+
+1;
+
+__END__

--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -1,0 +1,104 @@
+package Pakket::Installer;
+# ABSTRACT: Install pakket packages into an installation directory
+
+use Moose;
+use Path::Tiny        qw< path  >;
+use Types::Path::Tiny qw< Path  >;
+use File::HomeDir;
+
+# TODO:
+# * Recursively install
+# * Support .pakket.local (or .pakket.config local file configuration)
+# * Support multiple libraries
+# * Support active library
+
+# Sample structure:
+# ~/.pakket/
+#        bin/
+#        etc/
+#        repos/
+#        libraries/
+#                  active ->
+#
+
+has base_dir => (
+    is      => 'ro',
+    isa     => Path,
+    default => sub {
+        my $self = shift;
+        # 1. $ENV{'PKT_DIR'}: pre-enabled pakket installation
+        $ENV{'PKT_DIR'} && -d $ENV{'PKT_DIR'}
+            and return path( $ENV{'PKT_DIR'} );
+
+        # 2. /usr/local/pakket
+        my $base_dir = path( Path::Tiny->rootdir, qw< usr local pakket > );
+        if ( $base_dir->is_dir && -w $base_dir->stringify ) {
+            return $base_dir;
+        }
+
+        # 3. local .pakket in home directory
+        $base_dir = path( File::HomeDir->my_home, '.pakket' );
+
+        -d $base_dir
+            or $base_dir->mkpath;
+
+        # assert directory structure
+        my @dirs = (
+            $base_dir,
+            path( $base_dir, 'library' ),
+        );
+
+        foreach my $dir (@dirs) {
+            -d $dir or $dir->mkpath;
+        }
+
+        return $base_dir;
+    },
+    coerce  => 1,
+);
+
+has install_dir => (
+    is      => 'ro',
+    isa     => Path,
+    lazy    => 1,
+    coerce  => 1,
+    default => sub {
+        my $self = shift;
+        path( $self->base_dir, 'library' );
+    },
+);
+
+# TODO:
+# this should be implemented using a fetcher class
+# because it might be from HTTP/FTP/Git/Custom/etc.
+sub fetch_package;
+
+sub install_file {
+    my ( $self, $filename ) = @_;
+    my $install_dir = $self->install_dir;
+
+    -r( my $bundle_file = path($filename) )
+        or die "Bundle file '$filename' does not exist or can't be read\n";
+
+    my $bundle_basename = $bundle_file->basename;
+    $bundle_file->copy($install_dir);
+
+    # TODO: Archive::Any might fit here, but it doesn't support XZ
+    # introduce a plugin for it? It could be based on Archive::Tar
+    # but I'm not sure Archive::Tar support XZ either -- SX.
+    System::Command->spawn(
+        qw< tar -xJf >, $bundle_basename,
+        { cwd => $install_dir },
+    );
+
+    $install_dir->child( $bundle_basename )->remove;
+
+    print "Installed $bundle_basename in $install_dir\n";
+}
+
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__

--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -76,6 +76,8 @@ sub fetch_package;
 sub install_file {
     my ( $self, $filename ) = @_;
     my $install_dir = $self->install_dir;
+    -d $install_dir
+        or $install_dir->mkpath();
 
     -r( my $bundle_file = path($filename) )
         or die "Bundle file '$filename' does not exist or can't be read\n";


### PR DESCRIPTION
This addresses #23.

It has a lot of TODOs left but what we can now do is install a package file into a directory.

What we can do:
* Provide a file for installation.
* Have it install in a local pkt installation using an environment
  variable `PAKKET_DIR`.
* Have it install in a local pkt installation using in the home
  directory (`~/.pakket/`).
* Have it attempt to install in a global directory.
  (`/usr/local/pakket`, but that might be different on other OS'es.)

What we want to have:
* Be able to provide a URL for installation
  (HTTP, FTP, Git repo, etc.)
* Be able to provide a package name and have it pick from a
  default repository.
* Install dependencies recursively.
* Support multiple libraries (and a currently active one).