### PR TITLE
A few small bugfixes

### DIFF
--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -125,7 +125,6 @@ sub get_latest_version {
 }
 
 sub run_build {
-    # FIXME: we're currently not using the third parameter
     my ( $self, $category, $package_name, $package_args ) = @_;
 
     my $full_package_name = "$category/$package_name";
@@ -193,7 +192,7 @@ sub run_build {
                 my $prereq ( keys %{ $system_prereqs->{$prereq_category} } )
             {
                 $self->run_build( 'system', $prereq,
-                    $system_prereqs->{$prereq} );
+                    $system_prereqs->{$prereq_category}{$prereq} );
             }
         }
     }
@@ -202,7 +201,8 @@ sub run_build {
         foreach my $prereq_category (qw<configure runtime>) {
             foreach my $prereq ( keys %{ $perl_prereqs->{$prereq_category} } )
             {
-                $self->run_build( 'perl', $prereq, $perl_prereqs->{$prereq} );
+                $self->run_build( 'perl', $prereq,
+                    $perl_prereqs->{$prereq_category}{$prereq} );
             }
         }
     }

--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -385,7 +385,7 @@ sub build_perl_package {
     my $opts = {
         env => {
             PERL5LIB => path( $prefix, qw<lib perl5> )->stringify
-                . ':$PERL5LIB',
+                . ":$ENV{PERL5LIB}",
         },
     };
 

--- a/lib/Pakket/CLI/Command/build.pm
+++ b/lib/Pakket/CLI/Command/build.pm
@@ -79,7 +79,7 @@ sub validate_args {
         -d $opt->{'build_dir'}
             or die "You asked to use a build dir that does not exist.\n";
 
-        $self->{'build_dir'} = $opt->{'build_dir'};
+        $self->{'builder'}{'build_dir'} = path( $opt->{'build_dir'} );
     }
 
     $self->{'builder'}{'keep_build_dir'} = $opt->{'keep_build_dir'};


### PR DESCRIPTION
1. `$package_args` was not passed to `run_build()` so we were using the latest available version regardless of what was specified in the TOML config

2. `--build-dir` was not set when instantiating `Pakket::Builder`

3. `System::Command` modifies `%ENV` which is then inherited by the forked process but is not passed through shell expansion:
```
$ perl -e'$ENV{q{FOO}}=q{$PERL5LIB}; system("env")' | grep FOO
FOO=$PERL5LIB
```