### PR TITLE
Finally break apart builders to multiple classes:

### DIFF
--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -18,6 +18,9 @@ use Pakket::Log;
 use Pakket::Bundler;
 use Pakket::ConfigReader;
 use Pakket::Version::Requirements;
+use Pakket::Builder::NodeJS;
+use Pakket::Builder::Perl;
+use Pakket::Builder::System;
 
 use constant { ALL_PACKAGES_KEY => '', };
 
@@ -75,6 +78,18 @@ has index => (
     isa     => 'HashRef',
     lazy    => 1,
     default => sub { decode_json( path( $_[0]->index_file )->slurp_utf8 ) },
+);
+
+has 'builders' => (
+    'is'      => 'ro',
+    'isa'     => 'HashRef',
+    'default' => sub {
+        return [
+            'nodejs' => Pakket::Builder::NodeJS->new(),
+            'perl'   => Pakket::Builder::Perl->new(),
+            'system' => Pakket::Builder::System->new(),
+        ];
+    },
 );
 
 has bundler => (
@@ -280,14 +295,16 @@ sub run_build {
 
     my $main_build_dir = path( $top_build_dir, 'main' );
 
+    # FIXME: This shouldn't just be configure flags
+    # we should allow the builder to have access to a general
+    # metadata chunk which *might* include configure flags
     my $configure_flags = $self->get_configure_flags(
         $config->{'Package'}{'configure_flags'},
         { main_build_dir => $main_build_dir },
     );
 
-    # FIXME: Remove in favor of a ::Build::System, ::Build::Perl, etc.
     # FIXME: $package_dst_dir is dictated from the category
-    if ( $category eq 'system' ) {
+    if ( my $builder = $self->builders->{$category} ) {
         my $package_dst_dir = path(
             $top_build_dir,
             'src',
@@ -297,45 +314,14 @@ sub run_build {
 
         dircopy( $package_src_dir, $package_dst_dir );
 
-        $self->build_package(
-            $package_name,    # zeromq
-            $package_dst_dir, # /tmp/BUILD-1/src/system/zeromq-1.4.1
-            $main_build_dir,  # /tmp/BUILD-1/main
+        $builder->build_package(
+            $package_name,
+            $package_dst_dir,
+            $main_build_dir,
             $configure_flags,
         );
-    } elsif ( $category eq 'perl' ) {
-        my $package_dst_dir = path(
-            $top_build_dir,
-            'src',
-            $category,
-            basename($package_src_dir),
-        );
-
-        dircopy( $package_src_dir, $package_dst_dir );
-
-        $self->build_perl_package(
-            $package_name,    # ZMQ::Constants
-            $package_dst_dir, # /tmp/BUILD-1/src/perl/ZMQ-Constants-...
-            $main_build_dir,  # /tmp/BUILD-1/main
-        );
-    } elsif ( $category eq 'nodejs' ) {
-        my $package_dst_dir = path(
-            $top_build_dir,
-            'src',
-            $category,
-            basename($package_src_dir),
-        );
-
-        dircopy( $package_src_dir, $package_dst_dir );
-
-        $self->build_nodejs_package(
-            $package_name,    #
-            $package_dst_dir, #
-            $main_build_dir,  #
-        );
     } else {
-        $log->critical(
-            "Unrecognized category ($category), cannot build this.");
+        $log->critical("I do not have a builder for category $category.");
         exit 1;
     }
 
@@ -438,197 +424,6 @@ sub _diff_nodes_list {
     );
 
     return \%nodes_diff;
-}
-
-sub build_package {
-    my ( $self, $package, $build_dir, $prefix, $configure_flags ) = @_;
-
-    $log->info("Building $package");
-
-    my $my_library_path = $prefix->absolute->stringify;
-    if ( defined( my $env_library_path = $ENV{'LD_LIBRARY_PATH'} ) ) {
-        $my_library_path .= ":$env_library_path";
-    }
-
-    my $my_bin_path = $prefix->child('bin')->absolute->stringify;
-    if ( defined( my $env_bin_path = $ENV{'PATH'} ) ) {
-        $my_bin_path .= ":$env_bin_path";
-    }
-
-    my $opts = {
-        env => {
-            LD_LIBRARY_PATH => $my_library_path,
-            PATH            => $my_bin_path,
-        },
-    };
-
-    my $configurator;
-    if ( -x path( $build_dir, 'configure' ) ) {
-        $configurator = './configure';
-    } elsif ( -x path( $build_dir, 'config' ) ) {
-        $configurator = './config';
-    } else {
-        $log->critical("Don't know how to configure $package");
-        exit 1;
-    }
-
-    my @seq = (
-
-        # configure
-        [
-            $build_dir,
-            [
-                $configurator, '--prefix=' . $prefix->absolute,
-                @{$configure_flags},
-            ],
-            $opts,
-        ],
-
-        # build
-        [ $build_dir, ['make'], $opts, ],
-
-        # install
-        [ $build_dir, [ 'make', 'install' ], $opts, ],
-    );
-
-    my $success = $self->run_command_sequence(@seq);
-    unless ($success) {
-        $log->critical("Failed to build $package");
-        exit 1;
-    }
-
-    $log->info("Done preparing $package");
-}
-
-sub build_perl_package {
-    my ( $self, $package, $build_dir, $prefix ) = @_;
-
-    $log->info("Building Perl module: $package");
-
-    my @perl5lib = ( path( $prefix, qw<lib perl5> )->absolute->stringify );
-
-    my $my_library_path = $prefix->absolute->child('lib')->stringify;
-    if ( defined( my $env_library_path = $ENV{'LD_LIBRARY_PATH'} ) ) {
-        $my_library_path .= ":$env_library_path";
-    }
-
-    my $my_bin_path = $prefix->child('bin')->absolute->stringify;
-    if ( defined( my $env_bin_path = $ENV{'PATH'} ) ) {
-        $my_bin_path .= ":$env_bin_path";
-    }
-
-    my $opts = {
-        env => {
-            PERL5LIB                  => join( ':', @perl5lib ),
-            PERL_LOCAL_LIB_ROOT       => '',
-            PERL5_CPAN_IS_RUNNING     => 1,
-            PERL5_CPANM_IS_RUNNING    => 1,
-            PERL5_CPANPLUS_IS_RUNNING => 1,
-            PERL_MM_USE_DEFAULT       => 1,
-            PERL_MB_OPT               => '',
-            PERL_MM_OPT               => '',
-
-            CPATH           => $prefix->child('include'),
-            LD_LIBRARY_PATH => $my_library_path,
-            LIBRARY_PATH    => $my_library_path,
-            PATH            => $my_bin_path,
-        },
-    };
-
-    my $original_dir = Path::Tiny->cwd;
-    my $install_base = $prefix->absolute;
-
-    # taken from cpanminus
-    my %should_use_mm = map +( "perl/$_" => 1 ),
-        qw( version ExtUtils-ParseXS ExtUtils-Install ExtUtils-Manifest );
-
-    my @seq;
-    if ( $build_dir->child('Build.PL')->exists
-        && !exists $should_use_mm{$package} )
-    {
-        @seq = (
-
-            # configure
-            [
-                $build_dir,
-                [ 'perl', 'Build.PL', '--install_base', $install_base ],
-                $opts,
-            ],
-
-            # build
-            [ $build_dir, ['./Build'], $opts ],
-
-            # install
-            [ $build_dir, [ './Build', 'install' ], $opts ],
-        );
-    } elsif ( $build_dir->child('Makefile.PL')->exists ) {
-        @seq = (
-
-            # configure
-            [
-                $build_dir,
-                [ 'perl', 'Makefile.PL', "INSTALL_BASE=$install_base" ],
-                $opts,
-            ],
-
-            # build
-            [ $build_dir, ['make'], $opts ],
-
-            # install
-            [ $build_dir, [ 'make', 'install' ], $opts ],
-        );
-    } else {
-        die "Could not find an installer (Makefile.PL/Build.PL)\n";
-    }
-
-    my $success = $self->run_command_sequence(@seq);
-
-    chdir $original_dir;
-
-    unless ($success) {
-        $log->critical("Failed to build $package");
-        exit 1;
-    }
-
-    $log->info("Done preparing $package");
-}
-
-sub build_nodejs_package {
-    my ( $self, $package, $build_dir, $prefix ) = @_;
-
-    $log->info("Building NodeJS module: $package");
-
-    my $opts = {
-        env => {
-            LD_LIBRARY_PATH => $prefix->absolute->stringify . ':'
-                . ( $ENV{'LD_LIBRARY_PATH'} // '' ),
-
-            PATH => $prefix->child('bin')->absolute->stringify . ':'
-                . ( $ENV{'PATH'} // '' ),
-        },
-    };
-
-    my $original_dir = Path::Tiny->cwd;
-    my $install_base = $prefix->absolute;
-
-    my $source = $build_dir;
-    if ( $ENV{'NODE_NPM_REGISTRY'} ) {
-        $self->run_command( $build_dir,
-            [ qw< npm set registry >, $ENV{'NODE_NPM_REGISTRY'} ], $opts );
-        $source = $package;
-    }
-    my $success
-        = $self->run_command( $build_dir, [ qw< npm install -g >, $source ],
-        $opts );
-
-    chdir $original_dir;
-
-    unless ($success) {
-        $log->critical("Failed to build $package");
-        exit 1;
-    }
-
-    $log->info("Done preparing $package");
 }
 
 sub get_configure_flags {

--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -19,9 +19,7 @@ use Pakket::Bundler;
 use Pakket::ConfigReader;
 use Pakket::Version::Requirements;
 
-use constant {
-    ALL_PACKAGES_KEY => '',
-};
+use constant { ALL_PACKAGES_KEY => '', };
 
 with 'Pakket::Role::RunCommand';
 
@@ -44,7 +42,7 @@ has build_dir => (
     isa     => Path,
     coerce  => 1,
     lazy    => 1,
-    default => sub { Path::Tiny->tempdir('BUILD-XXXXXX', CLEANUP => 0 ) },
+    default => sub { Path::Tiny->tempdir( 'BUILD-XXXXXX', CLEANUP => 0 ) },
 );
 
 has keep_build_dir => (
@@ -87,9 +85,9 @@ has bundler => (
 );
 
 has bundler_args => (
-    is        => 'ro',
-    isa       => 'HashRef',
-    default   => sub { +{} },
+    is      => 'ro',
+    isa     => 'HashRef',
+    default => sub { +{} },
 );
 
 sub _build_bundler {
@@ -107,7 +105,7 @@ sub DEMOLISH {
     my $self      = shift;
     my $build_dir = $self->build_dir;
 
-    if ( ! $self->keep_build_dir ) {
+    if ( !$self->keep_build_dir ) {
         $log->info("Removing build dir $build_dir");
 
         # "safe" is false because it might hit files which it does not have
@@ -158,9 +156,10 @@ sub get_latest_satisfying_version {
 
     my $chosen = $req->pick_maximum_satisfying_version(
         [ keys %{ $self->index->{$category}{$package_name}{versions} } ] );
-	if ( !$chosen ) {
-		die "Could not find maximum satisfying version for $category/$package_name in index";
-	}
+    if ( !$chosen ) {
+        die
+            "Could not find maximum satisfying version for $category/$package_name in index";
+    }
     $log->debug("Chosen: $package_name $chosen");
 
     return $chosen;
@@ -249,7 +248,7 @@ sub run_build {
     # recursively build prereqs
     # starting with system libraries
 
-    foreach my $type ( qw< system perl nodejs > ) {
+    foreach my $type (qw< system perl nodejs >) {
         if ( my $prereqs = $config->{'Prereqs'}{$type} ) {
             foreach my $category (qw<configure runtime>) {
                 foreach my $prereq ( keys %{ $prereqs->{$category} } ) {
@@ -363,6 +362,7 @@ sub scan_dir {
     $error_out //= 1;
 
     $log->debug('Scanning directory.');
+
     # XXX: this is just a bit of a smarter && dumber rsync(1):
     # rsync -qaz BUILD/main/ output_dir/
     # the reason is that we need the diff.
@@ -375,15 +375,15 @@ sub scan_dir {
     );
 
     if ($error_out) {
-	    keys %{$package_files}
-		or $log->critical(
-		'This is odd. Build did not generate new files. Cannot package.'),
-		exit 1;
+        keys %{$package_files}
+            or $log->critical(
+            'This is odd. Build did not generate new files. Cannot package.'),
+            exit 1;
     }
 
     # store per all packages to get the diff
-    @{ $self->build_files_manifest }{ keys %{$package_files} } =
-        values %{$package_files};
+    @{ $self->build_files_manifest }{ keys %{$package_files} }
+        = values %{$package_files};
 
     return $package_files;
 }
@@ -391,12 +391,9 @@ sub scan_dir {
 sub retrieve_new_files {
     my ( $self, $category, $package_name, $build_dir ) = @_;
 
-
-    my $nodes     = $self->scan_directory($build_dir);
-    my $new_files = $self->_diff_nodes_list(
-        $self->build_files_manifest,
-        $nodes,
-    );
+    my $nodes = $self->scan_directory($build_dir);
+    my $new_files
+        = $self->_diff_nodes_list( $self->build_files_manifest, $nodes, );
 
     return $new_files;
 }
@@ -531,9 +528,9 @@ sub build_perl_package {
             PERL_MB_OPT               => '',
             PERL_MM_OPT               => '',
 
-		CPATH => $prefix->child('include'),
+            CPATH           => $prefix->child('include'),
             LD_LIBRARY_PATH => $my_library_path,
-            LIBRARY_PATH => $my_library_path,
+            LIBRARY_PATH    => $my_library_path,
             PATH            => $my_bin_path,
         },
     };
@@ -640,7 +637,7 @@ sub get_configure_flags {
     $config or return [];
 
     my @flags;
-    for my $tuple (@{$config}) {
+    for my $tuple ( @{$config} ) {
         if ( @{$tuple} > 2 ) {
             $log->criticalf( 'Odd configuration flag: %s', $tuple );
             exit 1;
@@ -657,7 +654,7 @@ sub get_configure_flags {
 sub _expand_flags_inplace {
     my ( $self, $flags, $env ) = @_;
 
-    for my $flag (@{$flags}) {
+    for my $flag ( @{$flags} ) {
         for my $key ( keys %{$env} ) {
             my $placeholder = '%' . uc($key) . '%';
             $flag =~ s/$placeholder/$env->{$key}/gsm;

--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -84,11 +84,11 @@ has 'builders' => (
     'is'      => 'ro',
     'isa'     => 'HashRef',
     'default' => sub {
-        return [
+        return {
             'nodejs' => Pakket::Builder::NodeJS->new(),
             'perl'   => Pakket::Builder::Perl->new(),
             'system' => Pakket::Builder::System->new(),
-        ];
+        };
     },
 );
 

--- a/lib/Pakket/Builder/NodeJS.pm
+++ b/lib/Pakket/Builder/NodeJS.pm
@@ -16,7 +16,7 @@ sub build_package {
 
     my $opts = {
         'env' => {
-            $self->generate_env_vars( 'prefix' => $prefix ),
+            $self->generate_env_vars($prefix),
         },
     };
 

--- a/lib/Pakket/Builder/NodeJS.pm
+++ b/lib/Pakket/Builder/NodeJS.pm
@@ -1,0 +1,55 @@
+package Pakket::Builder::NodeJS;
+# ABSTRACT: Build Perl Pakket packages
+
+use Moose;
+use English '-no_match_vars';
+use Log::Any   qw< $log >;
+use Path::Tiny qw< path >;
+use Pakket::Log;
+
+with qw<Pakket::Role::Builder>;
+
+sub build_package {
+    my ( $self, $package, $build_dir, $prefix ) = @_;
+
+    $log->info("Building NodeJS module: $package");
+
+    my $opts = {
+        'env' => {
+            $self->generate_env_vars( 'prefix' => $prefix ),
+        },
+    };
+
+    my $original_dir = Path::Tiny->cwd;
+    my $install_base = $prefix->absolute;
+
+    my $source = $build_dir;
+
+    if ( $ENV{'NODE_NPM_REGISTRY'} ) {
+        $self->run_command( $build_dir,
+            [ qw< npm set registry >, $ENV{'NODE_NPM_REGISTRY'} ], $opts );
+        $source = $package;
+    }
+
+    my $success
+        = $self->run_command( $build_dir, [ qw< npm install -g >, $source ],
+        $opts );
+
+    if ( !$success ) {
+        $log->critical("Failed to build $package");
+        exit 1;
+    }
+
+    $log->info("Done preparing $package");
+
+    return;
+}
+
+no Moose;
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=pod

--- a/lib/Pakket/Builder/Perl.pm
+++ b/lib/Pakket/Builder/Perl.pm
@@ -27,7 +27,7 @@ sub build_package {
             'PERL_MB_OPT'               => '',
             'PERL_MM_OPT'               => '',
 
-            $self->generate_env_vars( 'prefix' => $prefix ),
+            $self->generate_env_vars($prefix),
         },
     };
 

--- a/lib/Pakket/Builder/Perl.pm
+++ b/lib/Pakket/Builder/Perl.pm
@@ -1,0 +1,99 @@
+package Pakket::Builder::Perl;
+# ABSTRACT: Build Perl Pakket packages
+
+use Moose;
+use English '-no_match_vars';
+use Log::Any   qw< $log >;
+use Path::Tiny qw< path >;
+use Pakket::Log;
+
+with qw<Pakket::Role::Builder>;
+
+sub build_package {
+    my ( $self, $package, $build_dir, $prefix ) = @_;
+
+    $log->info("Building Perl module: $package");
+
+    my @perl5lib = ( path( $prefix, qw<lib perl5> )->absolute->stringify );
+
+    my $opts = {
+        'env' => {
+            'PERL5LIB'                  => join( ':', @perl5lib ),
+            'PERL_LOCAL_LIB_ROOT'       => '',
+            'PERL5_CPAN_IS_RUNNING'     => 1,
+            'PERL5_CPANM_IS_RUNNING'    => 1,
+            'PERL5_CPANPLUS_IS_RUNNING' => 1,
+            'PERL_MM_USE_DEFAULT'       => 1,
+            'PERL_MB_OPT'               => '',
+            'PERL_MM_OPT'               => '',
+
+            $self->generate_env_vars( 'prefix' => $prefix ),
+        },
+    };
+
+    my $original_dir = Path::Tiny->cwd;
+    my $install_base = $prefix->absolute;
+
+    # taken from cpanminus
+    my %should_use_mm = map +( "perl/$_" => 1 ),
+        qw( version ExtUtils-ParseXS ExtUtils-Install ExtUtils-Manifest );
+
+    my @seq;
+    if ( $build_dir->child('Build.PL')->exists
+        && !exists $should_use_mm{$package} )
+    {
+        @seq = (
+
+            # configure
+            [
+                $build_dir,
+                [ 'perl', 'Build.PL', '--install_base', $install_base ],
+                $opts,
+            ],
+
+            # build
+            [ $build_dir, ['./Build'], $opts ],
+
+            # install
+            [ $build_dir, [ './Build', 'install' ], $opts ],
+        );
+    } elsif ( $build_dir->child('Makefile.PL')->exists ) {
+        @seq = (
+
+            # configure
+            [
+                $build_dir,
+                [ 'perl', 'Makefile.PL', "INSTALL_BASE=$install_base" ],
+                $opts,
+            ],
+
+            # build
+            [ $build_dir, ['make'], $opts ],
+
+            # install
+            [ $build_dir, [ 'make', 'install' ], $opts ],
+        );
+    } else {
+        die "Could not find an installer (Makefile.PL/Build.PL)\n";
+    }
+
+    my $success = $self->run_command_sequence(@seq);
+
+    if ( !$success ) {
+        $log->critical("Failed to build $package");
+        exit 1;
+    }
+
+    $log->info("Done preparing $package");
+
+    return;
+}
+
+no Moose;
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=pod

--- a/lib/Pakket/Builder/System.pm
+++ b/lib/Pakket/Builder/System.pm
@@ -14,7 +14,7 @@ sub build_package {
     if (   $build_dir->child('configure')->exists
         || $build_dir->child('config')->exists )
     {
-        my $builder = Pakket::Builder::Makefile->new();
+        my $builder = Pakket::Builder::System::Makefile->new();
         $builder->build_package( $package, $build_dir, $prefix, $flags );
     } else {
         $log->critical("I cannot build this system package. No 'configure'.");

--- a/lib/Pakket/Builder/System.pm
+++ b/lib/Pakket/Builder/System.pm
@@ -1,0 +1,34 @@
+package Pakket::Builder::System;
+# ABSTRACT: Build System Pakket packages
+
+use Moose;
+use Log::Any qw< $log >;
+use Pakket::Log;
+use Pakket::Builder::System::Makefile;
+
+with qw<Pakket::Role::Builder>;
+
+sub build_package {
+    my ( $self, $package, $build_dir, $prefix, $flags ) = @_;
+
+    if (   $build_dir->child('configure')->exists
+        || $build_dir->child('config')->exists )
+    {
+        my $builder = Pakket::Builder::Makefile->new();
+        $builder->build_package( $package, $build_dir, $prefix, $flags );
+    } else {
+        $log->critical("I cannot build this system package. No 'configure'.");
+        exit 1;
+    }
+
+    return;
+}
+
+no Moose;
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=pod

--- a/lib/Pakket/Builder/System/Makefile.pm
+++ b/lib/Pakket/Builder/System/Makefile.pm
@@ -15,7 +15,7 @@ sub build_package {
 
     my $opts = {
         'env' => {
-            $self->generate_env_vars( 'prefix' => $prefix ),
+            $self->generate_env_vars($prefix),
         },
     };
 

--- a/lib/Pakket/Builder/System/Makefile.pm
+++ b/lib/Pakket/Builder/System/Makefile.pm
@@ -1,0 +1,72 @@
+package Pakket::Builder::System::Makefile;
+# ABSTRACT: Build System Pakket packages that use Makefile
+
+use Moose;
+use Log::Any   qw< $log >;
+use Path::Tiny qw< path >;
+use Pakket::Log;
+
+with qw<Pakket::Role::Builder>;
+
+sub build_package {
+    my ( $self, $package, $build_dir, $prefix, $flags ) = @_;
+
+    $log->info("Building System library: $package");
+
+    my $opts = {
+        'env' => {
+            $self->generate_env_vars( 'prefix' => $prefix ),
+        },
+    };
+
+    my $configurator;
+    if ( -x $build_dir->child('configure') ) {
+        $configurator = './configure';
+    } elsif ( -x $build_dir->child('config') ) {
+        $configurator = './config';
+    } else {
+        $log->critical( "Don't know how to configure $package"
+                . " (Cannot find executale 'configure' or 'config')" );
+        exit 1;
+    }
+
+    my @seq = (
+
+        # configure
+        [
+            $build_dir,
+            [
+                $configurator, '--prefix=' . $prefix->absolute,
+                @{$flags},
+            ],
+            $opts,
+        ],
+
+        # build
+        [ $build_dir, ['make'], $opts, ],
+
+        # install
+        [ $build_dir, [ 'make', 'install' ], $opts, ],
+    );
+
+    my $success = $self->run_command_sequence(@seq);
+
+    if ( !$success ) {
+        $log->critical("Failed to build $package");
+        exit 1;
+    }
+
+    $log->info("Done preparing $package");
+
+    return;
+}
+
+no Moose;
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=pod
+

--- a/lib/Pakket/Role/Builder.pm
+++ b/lib/Pakket/Role/Builder.pm
@@ -1,0 +1,48 @@
+package Pakket::Role::Builder;
+
+# ABSTRACT: A role for all builders
+
+use Moose::Role;
+
+with qw<Pakket::Role::RunCommand>;
+
+requires qw<build_package>;
+
+sub generate_env_vars {
+    my ( $self, $prefix ) = @_;
+    my $lib_path = $self->generate_lib_path($prefix);
+    my $bin_path = $self->generate_bin_path($prefix);
+
+    return (
+        'CPATH'           => $prefix->child('include'),
+        'LD_LIBRARY_PATH' => $lib_path,
+        'LIBRARY_PATH'    => $lib_path,
+        'PATH'            => $bin_path,
+    );
+}
+
+sub generate_lib_path {
+    my ( $self, $prefix ) = @_;
+
+    my $lib_path = $prefix->absolute->child('lib')->stringify;
+    if ( defined( my $env_library_path = $ENV{'LD_LIBRARY_PATH'} ) ) {
+        $lib_path .= ":$env_library_path";
+    }
+
+    return $lib_path;
+}
+
+sub generate_bin_path {
+    my ( $self, $prefix ) = @_;
+
+    my $bin_path = $prefix->child('bin')->absolute->stringify;
+    if ( defined( my $env_bin_path = $ENV{'PATH'} ) ) {
+        $bin_path .= ":$env_bin_path";
+    }
+
+    return $bin_path;
+}
+
+no Moose::Role;
+
+1;

--- a/lib/Pakket/Role/Builder.pm
+++ b/lib/Pakket/Role/Builder.pm
@@ -24,7 +24,7 @@ sub generate_env_vars {
 sub generate_lib_path {
     my ( $self, $prefix ) = @_;
 
-    my $lib_path = $prefix->absolute->child('lib')->stringify;
+    my $lib_path = $prefix->child('lib')->absolute->stringify;
     if ( defined( my $env_library_path = $ENV{'LD_LIBRARY_PATH'} ) ) {
         $lib_path .= ":$env_library_path";
     }


### PR DESCRIPTION
This has bugged me for a while. All the builders are now proper
classes, based on category.

There is a role that allows all builders to make sure they can
run commands and generate the proper environment variables.

Perl contains the code for both ExtUtils::MakeMaker and
Module::Build, while System delegates to a Makefile based one,
so it could also allow CMake and SCons when we encounter them in
the future.

What bugs me is that we fetch configure flags (which might or
might not exist) and then send it everywhere. Instead I would
prefer to have a general hash of metadata in which the configure
flags would be one possible field.

I'm still not sure how to introduce additional categories without
loading them in the Builder.pm object and adding them to the
"builders" attribute. Two possibilities exist:

1. Make this automatically load with Module::Pluggable, but that
   adds a problem when newer versions possibly remove outdated
   builders. They might remain from older versions and `cpan(m?)`
   doesn't remove before upgrading.

2. Add a configuration option to include additional ones, which
   makes more sense.

This closes GH #12.