### PR TITLE
GH #57: Builder: use Installer to unpack existing parcels

### DIFF
--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -160,10 +160,10 @@ sub DEMOLISH {
 sub _setup_build_dir {
     my $self = shift;
 
-    $log->debugf( 'Creating build dir %s', $self->build_dir );
+    $log->debugf( 'Creating build dir %s', $self->build_dir->stringify );
     my $prefix_dir = path( $self->build_dir, 'main' );
 
-    -d $prefix_dir or $prefix_dir->mkpath;
+    $prefix_dir->is_dir or $prefix_dir->mkpath;
 }
 
 sub get_latest_satisfying_version {

--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -156,7 +156,7 @@ sub install {
 sub install_package {
     my ( $self, $package, $dir, $installed ) = @_;
 
-    $log->debug("About to install $package");
+    $log->debug("About to install $package (into $dir)");
 
     if ( $installed->{$package}++ ) {
         $log->debug("$package already installed");
@@ -223,8 +223,7 @@ sub install_package {
     $dir->child($parcel_basename)->remove;
 
     my $spec_file = $full_parcel_dir->child( PARCEL_METADATA_FILE() );
-
-    my $config = decode_json $spec_file->slurp_utf8;
+    my $config    = decode_json $spec_file->slurp_utf8;
 
     my $prereqs = $config->{'Prereqs'};
     foreach my $prereq_category ( keys %{$prereqs} ) {


### PR DESCRIPTION
When the builder finds a requirement that is already packaged, it will unpack it in the build directory. Unfortunately this was a quick hack and was not recursive.

GH #57 shows this had an effect of inner dependencies being missing and breaking the build.

Since we now have a proper installer that can install separately from the set-up process of the install process, we can use that directly.

This can still be smoothed over in the future:

* We need to pass to the installer the directory straight from the "bundler_args" which is sub-optimal.

* We need to still verify that the parcel file exists in the builder and only then call the installer. Also sub-optimal.

* The builder and installer specify the packages in different strings and we need to translate from one to the other. Very simple, but will be unnecessary if we had package objects.