### PR TITLE
Add release data

### DIFF
--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -179,7 +179,9 @@ sub bootstrap_build {
     ## no critic qw(BuiltinFunctions::ProhibitComplexMappings Lax::ProhibitComplexMappings::LinesNotStatements)
     my %dist_reqs = map {;
         my $name    = $_;
-        my $ver_rel = $self->spec_repo->latest_version( $category, $name );
+        my $ver_rel = $self->spec_repo->latest_version_release(
+            $category, $name,
+        );
         my ( $version, $release ) = @{$ver_rel};
 
         $name => Pakket::Requirement->new(
@@ -281,12 +283,10 @@ sub run_build {
 
         # Check the releases mismatch
         if ( $built_release ne $prereq->release ) {
-            $log->criticalf(
+            die $log->criticalf(
                 'Asked to build %s when %s=%s:%s already built',
                 $prereq->full_name, $short_name, $built_version, $built_release,
             );
-
-            exit 1;
         }
 
         $log->debug(
@@ -453,7 +453,7 @@ sub _recursive_build_phase {
     my @prereqs = keys %{ $package->prereqs->{$category}{$phase} };
 
     foreach my $prereq_name (@prereqs) {
-        my $ver_rel = $self->spec_repo->latest_version(
+        my $ver_rel = $self->spec_repo->latest_version_release(
             $category, $prereq_name,
         );
 

--- a/lib/Pakket/CLI/Command/build.pm
+++ b/lib/Pakket/CLI/Command/build.pm
@@ -101,8 +101,14 @@ sub validate_args {
     }
 
     foreach my $spec_str (@specs) {
-        my ( $cat, $name, $version ) = $spec_str =~ PAKKET_PACKAGE_SPEC()
-            or $self->usage_error("Provide category/name, not '$spec_str'");
+        my ( $cat, $name, $version, $release ) =
+            $spec_str =~ PAKKET_PACKAGE_SPEC();
+
+        if ( ! ( $cat && $name && $version && $release ) ) {
+            $self->usage_error(
+                "Provide category/name=version:release, not '$spec_str'",
+            );
+        }
 
         my $req;
         eval { $req = Pakket::Requirement->new_from_string($spec_str); 1; }

--- a/lib/Pakket/CLI/Command/install.pm
+++ b/lib/Pakket/CLI/Command/install.pm
@@ -54,12 +54,12 @@ sub _determine_packages {
 
     my @packages;
     foreach my $package_str (@package_strs) {
-        my ( $pkg_cat, $pkg_name, $pkg_version ) =
+        my ( $pkg_cat, $pkg_name, $pkg_version, $pkg_release ) =
             $package_str =~ PAKKET_PACKAGE_SPEC();
 
-        if ( !defined $pkg_version ) {
+        if ( !defined $pkg_version || !defined $pkg_release ) {
             $self->usage_error(
-                'Currently you must provide a version to install: '
+                'Currently you must provide a version and release to install: '
                 .  $package_str,
             );
         }
@@ -68,6 +68,7 @@ sub _determine_packages {
             'category' => $pkg_cat,
             'name'     => $pkg_name,
             'version'  => $pkg_version,
+            'release'  => $pkg_release,
         );
     }
 

--- a/lib/Pakket/Constants.pm
+++ b/lib/Pakket/Constants.pm
@@ -10,16 +10,21 @@ use constant {
     'PARCEL_FILES_DIR'     => 'files',
     'PARCEL_METADATA_FILE' => 'meta.json',
 
-    # CATEGORY/PACKAGE         == latest version
-    # CATEGORY/PACKAGE=VERSION == Exact version
+    # CATEGORY/PACKAGE                 == latest version, latest release
+    # CATEGORY/PACKAGE=VERSION         == Exact version, latest release
+    # CATEGORY/PACKAGE=VERSION:RELEASE == Exact version and release
     'PAKKET_PACKAGE_SPEC'  => qr{
         ^
-        ([^/]+)     # category
+        ( [^/]+ )       # category
         /
-        ([^=]+)    # name
+        ( [^=]+ )       # name
         (?:
             =
-            (.+) # optional version
+            ( [^:]+ )   # optional version
+            (?:
+                :
+                (.*)    # optional release
+            )?
         )?
         $
     }xms,

--- a/lib/Pakket/Constants.pm
+++ b/lib/Pakket/Constants.pm
@@ -30,6 +30,7 @@ use constant {
     }xms,
 
     'PAKKET_LATEST_VERSION' => 'LATEST',
+    'PAKKET_DEFAULT_RELEASE' => 1,
 
     'PAKKET_INFO_FILE'      => 'info.json',
 };
@@ -40,6 +41,7 @@ our @EXPORT_OK = qw<
     PARCEL_METADATA_FILE
     PAKKET_PACKAGE_SPEC
     PAKKET_LATEST_VERSION
+    PAKKET_DEFAULT_RELEASE
     PAKKET_INFO_FILE
 >;
 

--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -200,8 +200,10 @@ sub install_package {
     $log->debugf( "About to install %s (into $dir)", $package->full_name );
 
     if ( defined $installer_cache->{$pkg_cat}{$pkg_name} ) {
-        my $version = $installer_cache->{$pkg_cat}{$pkg_name};
+        my $ver_rel = $installer_cache->{$pkg_cat}{$pkg_name};
+        my ( $version, $release ) = @{$ver_rel};
 
+        # Check version
         if ( $version ne $package->version ) {
             die $log->criticalf(
                 "%s=$version already installed. "
@@ -211,11 +213,26 @@ sub install_package {
             );
         }
 
+        # Check release
+        if ( $release ne $package->release ) {
+            $log->criticalf(
+                '%s=%s:%s already installed. '
+              . 'Cannot install new version: %s:%s',
+                $package->short_name,
+                $version, $release,
+                $package->release,
+            );
+
+            exit 1;
+        }
+
         $log->debugf( '%s already installed.', $package->full_name );
 
         return;
     } else {
-        $installer_cache->{$pkg_cat}{$pkg_name} = $package->version;
+        $installer_cache->{$pkg_cat}{$pkg_name} = [
+            $package->version, $package->release,
+        ];
     }
 
     if ( !is_writeable($dir) ) {
@@ -242,6 +259,7 @@ sub install_package {
         foreach my $prereq_name ( keys %{$runtime_prereqs} ) {
             my $prereq_data    = $runtime_prereqs->{$prereq_name};
             my $prereq_version = $prereq_data->{'version'};
+            my $prereq_release = $prereq_data->{'release'};
 
             # FIXME: This should be removed when we introduce version ranges
             # This forces us to install the latest version we have of
@@ -255,6 +273,7 @@ sub install_package {
                 'category' => $prereq_category,
                 'name'     => $prereq_name,
                 'version'  => $prereq_version,
+                'release'  => $prereq_release,
             );
 
             $self->install_package(
@@ -305,6 +324,7 @@ sub _update_info_file {
                 'category' => $package->category,
                 'name'     => $package->name,
                 'version'  => $package->version,
+                'release'  => $package->release,
             };
         },
         { 'recurse' => 1 },
@@ -314,6 +334,7 @@ sub _update_info_file {
         $package->category => {
             $package->name => {
                 'version'   => $package->version,
+                'release'   => $package->release,
                 'files'     => [ keys %files ],
                 'as_prereq' => $opts->{'as_prereq'} ? 1 : 0,
                 'prereqs'   => $package->prereqs,

--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -215,15 +215,13 @@ sub install_package {
 
         # Check release
         if ( $release ne $package->release ) {
-            $log->criticalf(
+            die $log->criticalf(
                 '%s=%s:%s already installed. '
               . 'Cannot install new version: %s:%s',
                 $package->short_name,
                 $version, $release,
                 $package->release,
             );
-
-            exit 1;
         }
 
         $log->debugf( '%s already installed.', $package->full_name );
@@ -257,17 +255,17 @@ sub install_package {
         my $runtime_prereqs = $prereqs->{$prereq_category}{'runtime'};
 
         foreach my $prereq_name ( keys %{$runtime_prereqs} ) {
-            my $prereq_data    = $runtime_prereqs->{$prereq_name};
-            my $prereq_version = $prereq_data->{'version'};
-            my $prereq_release = $prereq_data->{'release'};
+            my $prereq_data = $runtime_prereqs->{$prereq_name};
 
             # FIXME: This should be removed when we introduce version ranges
             # This forces us to install the latest version we have of
             # something, instead of finding the latest, based on the
             # version range, which "$prereq_version" contains. -- SX
-            $prereq_version = $self->parcel_repo->latest_version(
+            my $ver_rel = $self->parcel_repo->latest_version_release(
                 $prereq_category, $prereq_name,
             );
+
+            my ( $prereq_version, $prereq_release ) = @{$ver_rel};
 
             my $prereq = Pakket::Requirement->new(
                 'category' => $prereq_category,

--- a/lib/Pakket/Package.pm
+++ b/lib/Pakket/Package.pm
@@ -3,10 +3,12 @@ package Pakket::Package;
 
 use Moose;
 use MooseX::StrictConstructor;
+use Pakket::Types;
+use Pakket::Constants qw< PAKKET_DEFAULT_RELEASE >;
 
 with qw< Pakket::Role::BasicPackageAttrs >;
 
-has [ qw< name category version > ] => (
+has [ qw< name category version release > ] => (
     'is'       => 'ro',
     'isa'      => 'Str',
     'required' => 1,
@@ -85,7 +87,7 @@ sub spec {
             # if not required -- SX
             ( 'is_bootstrap' => 1 )x!! $self->is_bootstrap,
 
-            map +( $_ => $self->$_ ), qw<category name version>,
+            map +( $_ => $self->$_ ), qw<category name version release>,
         },
 
         'Prereqs' => $self->prereqs,

--- a/lib/Pakket/Repository.pm
+++ b/lib/Pakket/Repository.pm
@@ -69,7 +69,7 @@ sub remove_package_file {
     $self->remove_location( $package->id );
 }
 
-sub latest_version {
+sub latest_version_release {
     my ( $self, $category, $name ) = @_;
 
     # TODO: This is where the version comparison goes...
@@ -78,7 +78,10 @@ sub latest_version {
 
     # I don't like this, but okay...
     if ( $all[0] =~ PAKKET_PACKAGE_SPEC() ) {
-        return $3;
+        my ( $version, $release ) = ( $3, $4 );
+
+        defined $version && defined $release
+            and return [ $version, $release ];
     }
 
     die $log->criticalf(

--- a/lib/Pakket/Requirement.pm
+++ b/lib/Pakket/Requirement.pm
@@ -5,7 +5,10 @@ use Moose;
 use MooseX::StrictConstructor;
 
 use Log::Any          qw< $log >;
-use Pakket::Constants qw< PAKKET_PACKAGE_SPEC >;
+use Pakket::Constants qw<
+    PAKKET_PACKAGE_SPEC
+    PAKKET_DEFAULT_RELEASE
+>;
 use Pakket::Types;
 
 with qw< Pakket::Role::BasicPackageAttrs >;
@@ -19,8 +22,15 @@ has [qw< category name >] => (
 has 'version' => (
     'is'       => 'ro',
     'isa'      => 'PakketVersion',
-    'required' => 1,
     'coerce'   => 1,
+    'required' => 1,
+);
+
+has 'release' => (
+    'is'      => 'ro',
+    'isa'     => 'PakketRelease',
+    'coerce'  => 1,
+    'default' => sub { PAKKET_DEFAULT_RELEASE() },
 );
 
 has 'is_bootstrap' => (

--- a/lib/Pakket/Role/BasicPackageAttrs.pm
+++ b/lib/Pakket/Role/BasicPackageAttrs.pm
@@ -12,7 +12,7 @@ sub short_name {
 sub full_name {
     my $self = shift;
     return canonical_package_name(
-        $self->category, $self->name, $self->version,
+        $self->category, $self->name, $self->version, $self->release,
     );
 }
 

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -242,9 +242,11 @@ sub create_spec_for {
 
     my $package_spec = {
         'Package' => {
+            'release'  => 1,
             'category' => 'perl',
             'name'     => $dist_name,
             'version'  => $rel_version,
+            'release'  => 1,
         },
     };
 

--- a/lib/Pakket/Types.pm
+++ b/lib/Pakket/Types.pm
@@ -7,8 +7,13 @@ use warnings;
 use Moose::Util::TypeConstraints;
 use Log::Any qw< $log >;
 use Safe::Isa;
-use Module::Runtime qw<require_module>;
-use Pakket::Constants qw< PAKKET_LATEST_VERSION >;
+use Module::Runtime qw< require_module >;
+use Pakket::Constants qw<
+    PAKKET_LATEST_VERSION
+    PAKKET_DEFAULT_RELEASE
+>;
+
+# PakketRepositoryBackend
 
 sub _coerce_backend_from_arrayref {
     my $backend_data = shift;
@@ -31,10 +36,19 @@ subtype 'PakketRepositoryBackend', as 'Object', where {
 coerce 'PakketRepositoryBackend', from 'ArrayRef',
     via { return _coerce_backend_from_arrayref($_); };
 
+# PakketVersion
+
 subtype 'PakketVersion', as 'Str';
 
 coerce 'PakketVersion', from 'Undef',
     via { return PAKKET_LATEST_VERSION() };
+
+# PakketRelease
+
+subtype 'PakketRelease', as 'Str';
+
+coerce 'PakketRelease', from 'Undef',
+    via { return PAKKET_DEFAULT_RELEASE() };
 
 no Moose::Util::TypeConstraints;
 

--- a/lib/Pakket/Types.pm
+++ b/lib/Pakket/Types.pm
@@ -45,7 +45,7 @@ coerce 'PakketVersion', from 'Undef',
 
 # PakketRelease
 
-subtype 'PakketRelease', as 'Str';
+subtype 'PakketRelease', as 'Int';
 
 coerce 'PakketRelease', from 'Undef',
     via { return PAKKET_DEFAULT_RELEASE() };

--- a/lib/Pakket/Utils.pm
+++ b/lib/Pakket/Utils.pm
@@ -80,10 +80,11 @@ sub generate_bin_path {
 }
 
 sub canonical_package_name {
-    my ( $category, $package, $version ) = @_;
+    my ( $category, $package, $version, $release ) = @_;
 
-    $version
-        and return sprintf( '%s/%s=%s', $category, $package, $version );
+    if ( $version && $release ) {
+        return sprintf '%s/%s=%s:%s', $category, $package, $version, $release;
+    }
 
     return sprintf( '%s/%s', $category, $package );
 }


### PR DESCRIPTION
This finally adds the **release** information for each package and requirement. It changed a bit of the internals to account for it in pretty much everywhere, including caches and serialization. This also allowed cleaning up a few things (some of which I first pushed to *master* and then rebased).

I think it still needs some heavy testing to verify everything. Rebuilding everything with it before merging is probably good enough, but now with this change and the global configuration file, we can probably start writing tests again.