### PR TITLE
Add validating config parameters for 'pakket manage show'

### DIFF
--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -130,6 +130,7 @@ sub _validate_repos {
         'add'    => [ 'spec', 'source' ],
         'remove' => [ 'spec', 'source' ],
         'deps'   => [ 'spec' ],
+        'show'   => [ 'spec' ],
         'list'   => {
             spec   => [ 'spec'   ],
             parcel => [ 'parcel' ],


### PR DESCRIPTION
There was an error:
Can't use an undefined value as an ARRAY reference at
    pakket/lib/Pakket/CLI/Command/manage.pm line 144.