### PR TITLE
Check repo settings in config file (not in cmd)

### DIFF
--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -148,9 +148,11 @@ sub _validate_repos {
     for my $type ( @required_repos ) {
         my $opt_key   = $repo_opt{$type};
         my $directory = $self->{'opt'}{$opt_key};
-        my $repo_conf = $self->gen_repo_config( $type, $directory );
-        $repo_conf or $self->usage_error("Missing configuration for $type repository");
-        $config->{'repositories'}{$type} = $repo_conf;
+        if ( my $repo_conf_cmd = $self->gen_repo_config( $type, $directory ) ) {
+            $config->{'repositories'}{$type} = $repo_conf_cmd;
+        }
+        $config->{'repositories'}{$type}
+            or $self->usage_error("Missing configuration for $type repository");
     }
 }
 


### PR DESCRIPTION
Fix error when repo is defined in config, but is not defined in cmd.