### PR TITLE
Scaffolder: skip if we already have a satisfying version.

### DIFF
--- a/lib/Dancer2/Plugin/Pakket/ParamTypes.pm
+++ b/lib/Dancer2/Plugin/Pakket/ParamTypes.pm
@@ -28,6 +28,18 @@ sub BUILD {
     );
 
     $self->register_type_action(
+        'MissingName' => sub {
+            send_error( 'Missing or incorrect Name', HTTP_USER_ERROR() );
+        },
+    );
+
+    $self->register_type_action(
+        'MissingCategory' => sub {
+            send_error( 'Missing or incorrect Category', HTTP_USER_ERROR() );
+        },
+    );
+
+    $self->register_type_action(
         'MissingContent' => sub {
             send_error( 'Missing or incorrect content', HTTP_USER_ERROR() );
         },

--- a/lib/Pakket/Repository.pm
+++ b/lib/Pakket/Repository.pm
@@ -20,7 +20,7 @@ has 'backend' => (
     'lazy'    => 1,
     'builder' => '_build_backend',
     'handles' => [ qw<
-        all_object_ids has_object
+        all_object_ids all_object_ids_by_name has_object
         store_content  retrieve_content  remove_content
         store_location retrieve_location remove_location
     > ],

--- a/lib/Pakket/Repository/Backend/File.pm
+++ b/lib/Pakket/Repository/Backend/File.pm
@@ -10,6 +10,7 @@ use Log::Any          qw< $log >;
 use Types::Path::Tiny qw< Path AbsPath >;
 use Digest::SHA       qw< sha1_hex >;
 use Pakket::Utils     qw< encode_json_canonical encode_json_pretty >;
+use Pakket::Constants qw< PAKKET_PACKAGE_SPEC >;
 
 with qw<
     Pakket::Role::Repository::Backend
@@ -63,6 +64,14 @@ sub _build_repo_index {
 sub all_object_ids {
     my $self           = shift;
     my @all_object_ids = keys %{ $self->repo_index };
+    return \@all_object_ids;
+}
+
+sub all_object_ids_by_name {
+    my ( $self, $name, $category ) = @_;
+    my @all_object_ids =
+        grep { $_ =~ PAKKET_PACKAGE_SPEC(); $1 eq $category and $2 eq $name }
+        keys %{ $self->repo_index };
     return \@all_object_ids;
 }
 

--- a/lib/Pakket/Repository/Backend/HTTP.pm
+++ b/lib/Pakket/Repository/Backend/HTTP.pm
@@ -70,6 +70,23 @@ sub all_object_ids {
     return $content->{'object_ids'};
 }
 
+sub all_object_ids_by_name {
+    my ( $self, $name, $category ) = @_;
+    my $response = $self->http_client->get(
+        sprintf( '%s/all_object_ids_by_name?name=%s&category=%s',
+            $self->base_url, uri_escape($name), uri_escape($category),
+        )
+    );
+
+    if ( !$response->{'success'} ) {
+        croak( $log->criticalf( 'Could not get remote all_object_ids: %d -- %s',
+            $response->{'status'}, $response->{'reason'} ) );
+    }
+
+    my $content = decode_json( $response->{'content'} );
+    return $content->{'object_ids'};
+}
+
 sub has_object {
     my ( $self, $id ) = @_;
     my $response = $self->http_client->get(

--- a/lib/Pakket/Role/Repository/Backend.pm
+++ b/lib/Pakket/Role/Repository/Backend.pm
@@ -6,7 +6,7 @@ use Moose::Role;
 # These are helper methods we want the backend to implement
 # in order for the Repository to easily use across any backend
 requires qw<
-    all_object_ids has_object
+    all_object_ids all_object_ids_by_name has_object
 
     store_content  retrieve_content  remove_content
     store_location retrieve_location remove_location

--- a/lib/Pakket/Server/App.pm
+++ b/lib/Pakket/Server/App.pm
@@ -49,6 +49,17 @@ sub setup {
                 });
             };
 
+            get '/all_object_ids_by_name' => with_types [
+                [ 'query', 'name',     'Str', 'MissingName' ],
+                [ 'query', 'category', 'Str', 'MissingCategory' ],
+            ] => sub {
+                my $name     = query_parameters->get('name');
+                my $category = query_parameters->get('category');
+                return encode_json({
+                    'object_ids' => $repo->all_object_ids_by_name($name, $category),
+                });
+            };
+
             prefix '/retrieve' => sub {
                 get '/content' => with_types [
                     [ 'query', 'id', 'Str', 'MissingID' ],

--- a/lib/Pakket/Versioning.pm
+++ b/lib/Pakket/Versioning.pm
@@ -85,6 +85,14 @@ sub latest {
     return $latest;
 }
 
+sub is_satisfying {
+    my ( $self, $req_string, @versions ) = @_;
+
+    # Filter all @versions based on $req_string
+    $self->filter_version( $req_string, \@versions );
+
+    return !!( @versions > 0 );
+}
 
 no Moose;
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
Scaffolder will skip a requsts to add a dependency package,
if it can already find a satisfying version of that package
in the spec repo.

