### PR TITLE
show installed packages + don't install package it is already installed

### DIFF
--- a/lib/Pakket/CLI/Command/install.pm
+++ b/lib/Pakket/CLI/Command/install.pm
@@ -99,6 +99,7 @@ sub opt_spec {
         [ 'input-file=s',   'install eveything listed in this file' ],
         [ 'config|c=s',     'configuration file' ],
         [ 'show-installed', 'print list of installed packages' ],
+        [ 'force|f',        'force reinstall if package exists' ],
         [
             'verbose|v+',
             'verbose output (can be provided multiple times)',
@@ -123,8 +124,9 @@ sub execute {
     my ( $self, $opt ) = @_;
 
     my $installer = Pakket::Installer->new(
-        'config'     => $opt->{'config'},
-        'pakket_dir' => $opt->{'config'}{'install_dir'},
+        'config'          => $opt->{'config'},
+        'pakket_dir'      => $opt->{'config'}{'install_dir'},
+        'force_reinstall' => $opt->{'force'},
     );
 
     $opt->{'show_installed'}

--- a/lib/Pakket/CLI/Command/install.pm
+++ b/lib/Pakket/CLI/Command/install.pm
@@ -96,8 +96,9 @@ sub opt_spec {
             'from=s',
             'directory to install the packages from',
         ],
-        [ 'input-file=s', 'install eveything listed in this file' ],
-        [ 'config|c=s',   'configuration file' ],
+        [ 'input-file=s',   'install eveything listed in this file' ],
+        [ 'config|c=s',     'configuration file' ],
+        [ 'show-installed', 'print list of installed packages' ],
         [
             'verbose|v+',
             'verbose output (can be provided multiple times)',
@@ -125,6 +126,9 @@ sub execute {
         'config'     => $opt->{'config'},
         'pakket_dir' => $opt->{'config'}{'install_dir'},
     );
+
+    $opt->{'show_installed'}
+        and return $installer->show_installed();
 
     return $installer->install( @{ $opt->{'packages'} } );
 }

--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -249,6 +249,12 @@ sub pre_install_checks {
     }
 }
 
+sub show_installed {
+    my $self = shift;
+    my $installed_packages = $self->load_installed_packages($self->active_dir);
+    print join("\n", sort keys %{$installed_packages} ) . "\n";
+}
+
 __PACKAGE__->meta->make_immutable;
 
 no Moose;

--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -32,12 +32,23 @@ with qw<
     Pakket::Role::RunCommand
 >;
 
+has 'force_reinstall' => (
+    'is'      => 'ro',
+    'isa'     => 'Bool',
+    'default' => sub {0},
+);
+
 sub install {
     my ( $self, @packages ) = @_;
 
     if ( !@packages ) {
         $log->notice('Did not receive any parcels to deliver');
         return;
+    }
+
+    if ( !$self->force_reinstall ) {
+        @packages = $self->drop_installed_packages(@packages);
+        @packages or return;
     }
 
     my $installer_cache = {};
@@ -253,6 +264,21 @@ sub show_installed {
     my $self = shift;
     my $installed_packages = $self->load_installed_packages($self->active_dir);
     print join("\n", sort keys %{$installed_packages} ) . "\n";
+}
+
+sub drop_installed_packages {
+    my $self = shift;
+    my @packages = @_;
+    my $installed_packages = $self->load_installed_packages($self->active_dir);
+    my @out;
+    for my $package (@packages) {
+        if ($installed_packages->{$package->full_name}) {
+            $log->infof( '%s already installed', $package->full_name );
+        } else {
+            push @out, $package;
+        }
+    }
+    return @out;
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
I merged two commits in one pull-request because they are sharing the same code

commit a2495fcbc50156953274b535c4536723df639cd4
    Don't install package if it's already installed
    Add option --force|-f to force reinstallation of existing package.

commit 1586d07680b7c044d09c473618c00ed4ca05f7ef
    Add option --show-installed in installer
    To print list of installed packages
    pakket install --show-installed
