### PR TITLE
Uninstaller: check existence of file before removing

### DIFF
--- a/lib/Pakket/Uninstaller.pm
+++ b/lib/Pakket/Uninstaller.pm
@@ -180,7 +180,7 @@ sub delete_package {
         my ( $type, $file_name ) = $file =~ /(\w+)\/(.+)/;
         my $path = $self->work_dir->child($file_name);
         $log->debugf( "Deleting file %s", $path );
-        if ( !$path->remove ) {
+        if ($path->exists and !$path->remove ) {
             $log->error("Could not remove $path: $!");
         }
 


### PR DESCRIPTION
Don't blame if file doesn't exist