### PR TITLE
load_installed_packages: return full dependency tree

### DIFF
--- a/lib/Pakket/Requirement.pm
+++ b/lib/Pakket/Requirement.pm
@@ -6,6 +6,7 @@ use MooseX::StrictConstructor;
 
 use Carp     qw< croak >;
 use Log::Any qw< $log >;
+use Pakket::Utils qw< canonical_package_name >;
 
 has [ qw< category name > ] => (
     'is'       => 'ro',
@@ -18,6 +19,11 @@ has 'version' => (
     'isa'     => 'Str',
     'default' => sub { '>= 0' },
 );
+
+sub short_name {
+    my $self = shift;
+    return canonical_package_name( $self->category, $self->name );
+}
 
 no Moose;
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
Format:
```
my $installed_packages =
{
    "perl/Scalar-List-Utils" => {
        package => bless( {
                category     => "perl",
                is_bootstrap => 0,
                name         => "Scalar-List-Utils",
                release      => 1,
                version      => 1.47,
            }, "Pakket::PackageQuery" ),
        prereqs => {
            "perl/Test-Simple" => bless({
                    category  => "perl",
                    name      => "Test-Simple",
                    version   => 0
                }, "Pakket::Requirement"),
        },
        used_by =>{
                "perl/File-Temp"   => 1,
                "perl/Task-Weaken" => 1,
                "perl/Test-Simple" => 1
            },
    },
};
```