### PR TITLE
installer: rename variable force_reinstall -> force

### DIFF
--- a/lib/Pakket/CLI/Command/install.pm
+++ b/lib/Pakket/CLI/Command/install.pm
@@ -126,7 +126,7 @@ sub execute {
     my $installer = Pakket::Installer->new(
         'config'          => $opt->{'config'},
         'pakket_dir'      => $opt->{'config'}{'install_dir'},
-        'force_reinstall' => $opt->{'force'},
+        'force' => $opt->{'force'},
     );
 
     $opt->{'show_installed'}

--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -32,7 +32,7 @@ with qw<
     Pakket::Role::RunCommand
 >;
 
-has 'force_reinstall' => (
+has 'force' => (
     'is'      => 'ro',
     'isa'     => 'Bool',
     'default' => sub {0},
@@ -46,7 +46,7 @@ sub install {
         return;
     }
 
-    if ( !$self->force_reinstall ) {
+    if ( !$self->force ) {
         @packages = $self->drop_installed_packages(@packages);
         @packages or return;
     }


### PR DESCRIPTION
Renamed it because:
- it will have the same name as cmd parameter 'installer --force'
- it means not only force reinstallation of existed packages
    but also force installation with other failures,
    i.e. broken dependencies between packages,