### PR TITLE
Add BasicPackageAttrs in Pakket::Requirement

### DIFF
--- a/lib/Pakket/Requirement.pm
+++ b/lib/Pakket/Requirement.pm
@@ -7,6 +7,8 @@ use MooseX::StrictConstructor;
 use Carp     qw< croak >;
 use Log::Any qw< $log >;
 
+with qw< Pakket::Role::BasicPackageAttrs >;
+
 has [ qw< category name > ] => (
     'is'       => 'ro',
     'isa'      => 'Str',


### PR DESCRIPTION
To have for Requirement access to functions:
- short_name()
- full_name()
- id()