### PR TITLE
Scaffolder: fix is_local to work with deps

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'Algorithm::Diff::Callback';
 requires 'App::Cmd';
 requires 'Archive::Any';
 requires 'IO::Prompt::Tiny';
+requires 'CPAN::DistnameInfo';
 requires 'CPAN::Meta::Requirements', '>= 2.140';
 requires 'File::Basename';
 requires 'File::Copy::Recursive';

--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -40,7 +40,7 @@ sub opt_spec {
         [ 'remove=s%',    '(deps) add the following dependency (phase=category/name=version[:release])' ],
         [ 'cpan-02packages=s', '02packages file (optional)' ],
         [ 'no-deps',      'do not add dependencies (top-level only)' ],
-        [ 'is-local',     'do not use upstream sources (i.e. CPAN)' ],
+        [ 'is-local=s@',  'do not use upstream sources (i.e. CPAN) for given packages' ],
         [ 'requires-only', 'do not set recommended/suggested dependencies' ],
         [ 'no-bootstrap',  'skip bootstrapping phase (toolchain packages)' ],
     );
@@ -72,6 +72,10 @@ sub execute {
         $self->{'cpanfile'} ? 'perl' :
         undef;
 
+    my $is_local = +{
+        map { $_ => 1, s/-/::/gr => 1 } @{ $self->{'opt'}{'is_local'} }
+    };
+
     my $manager = Pakket::Manager->new(
         config          => $self->{'config'},
         cpanfile        => $self->{'cpanfile'},
@@ -80,9 +84,9 @@ sub execute {
         package         => $self->{'spec'},
         file_02packages => $self->{'file_02packages'},
         no_deps         => $self->{'opt'}{'no_deps'},
-        is_local        => $self->{'opt'}{'is_local'},
         requires_only   => $self->{'opt'}{'requires_only'},
         no_bootstrap    => $self->{'opt'}{'no_bootstrap'},
+        is_local        => $is_local,
     );
 
     if ( $command eq 'add' ) {

--- a/lib/Pakket/Manager.pm
+++ b/lib/Pakket/Manager.pm
@@ -53,8 +53,8 @@ has 'no_deps' => (
 
 has 'is_local' => (
     'is'        => 'ro',
-    'isa'       => 'Bool',
-    'default'   => 0,
+    'isa'       => 'HashRef',
+    'default'   => sub { +{} },
 );
 
 has 'requires_only' => (
@@ -206,7 +206,7 @@ sub _gen_scaffolder_perl {
     my %params = (
         'config'   => $self->config,
         'phases'   => $self->phases,
-        'no_deps'  => ( $self->is_local ? 1 : $self->no_deps ),
+        'no_deps'  => $self->no_deps,
         'is_local' => $self->is_local,
         ( 'types'  => ['requires'] )x!! $self->requires_only,
     );
@@ -215,14 +215,15 @@ sub _gen_scaffolder_perl {
         $params{'cpanfile'} = $self->cpanfile;
 
     } else {
+        my $name = $self->package->name;
         my $version = $self->package->version;
         # hack to pass exact version in prereq syntax
         defined $version
-            and !$self->is_local
+            and !$self->is_local->{ $name }
             and ref($self->package) eq 'Pakket::PackageQuery'
             and $version =~ s/^/== /;
 
-        $params{'module'}  = $self->package->name;
+        $params{'module'}  = $name;
         $params{'version'} = $version;
     }
 


### PR DESCRIPTION
This change will allow to use it separately from --no-deps
and will add the read requirements found in the local package's
META.json/META.yml files.

The --is-local flag now takes mulitiple values of all
package names you want to include from local directory
(so that they can be added as deps of each other).

Note: finding the version of a local dependency still requires
some work (next task).
for now we just list the matching files with the same
prefix and pull the last one (meaning you better not have
multiple versions of a local module in the cache dir).