### PR TITLE
Using Perl versioner for native packages

### DIFF
--- a/lib/Pakket/Repository.pm
+++ b/lib/Pakket/Repository.pm
@@ -82,6 +82,7 @@ sub latest_version_release {
     # Category -> Versioning type class
     my %types = (
         'perl' => 'Perl',
+        'native' => 'Perl',
     );
 
     my @versions;


### PR DESCRIPTION
That is temporary solution, but it works. We should probably create own versioner for native packages.