### PR TITLE
Scaffolder: only work with 'modules'

### DIFF
--- a/lib/Pakket/Role/Perl/BootstrapModules.pm
+++ b/lib/Pakket/Role/Perl/BootstrapModules.pm
@@ -11,9 +11,9 @@ has 'perl_bootstrap_modules' => (
     'isa'     => 'ArrayRef',
     'default' => sub {
         [qw<
-            ExtUtils-MakeMaker
-            Module-Build
-            Module-Build-WithXSpp
+            ExtUtils::MakeMaker
+            Module::Build
+            Module::Build::WithXSpp
         >]
     },
 );


### PR DESCRIPTION
This fixes GH#155

The issue is working with distribution names in Perl is not
always possible when info sources (02package) and requirement
parsing tools only recognize package (module) names.