### PR TITLE
scaffolder: fix has_satisfying()

### DIFF
--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -318,24 +318,18 @@ sub unpack {
 }
 
 sub has_satisfying {
-    my ( $self, $name, $requirements ) = @_;
+    my ( $self, $module_name, $requirements ) = @_;
     my $req_as_hash = $requirements->as_string_hash;
 
-    # fix requirement entries from module name to distribution
-    # so we can match to $name
-    for my $m ( keys %{ $req_as_hash } ) {
-        my $v = delete $req_as_hash->{$m};
-        next if $self->skip_name($m);
-        my $d = $self->get_dist_name($m);
-        $req_as_hash->{$d} = $v;
-    }
-    return unless exists $req_as_hash->{$name};
+    return unless exists $req_as_hash->{$module_name};
+
+    my $dist_name = $self->get_dist_name($module_name);
 
     my @versions = map { $_ =~ PAKKET_PACKAGE_SPEC(); $3 }
-        @{ $self->spec_repo->all_object_ids_by_name($name, 'perl') };
+        @{ $self->spec_repo->all_object_ids_by_name($dist_name, 'perl') };
     return unless @versions;
 
-    return $self->versioner->is_satisfying($req_as_hash->{$name}, @versions);
+    return $self->versioner->is_satisfying($req_as_hash->{$module_name}, @versions);
 }
 
 sub create_spec_for {


### PR DESCRIPTION
Now this function receives as parameters 'module_name' and
'requirements' of module_names,
so we don't have to convert requirements from 'module_name' to 'distr_name',

but all_object_ids_by_name() receives 'dist_name', so we have to convert it.