### PR TITLE
scaffolder: change order of operators

### DIFF
--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -341,8 +341,8 @@ sub has_satisfying {
 sub create_spec_for {
     my ( $self, $name, $requirements ) = @_;
 
-    return if $self->skip_name($name);
     return if $self->processed_dists->{ $name }++;
+    return if $self->skip_name($name);
     return if $self->has_satisfying($name, $requirements);
 
     my $release = $self->get_release_info( $name, $requirements );


### PR DESCRIPTION
This is very minor patch. To detect that we shouldn't process a module,
first check the module name in hash of duplicates,
then check it via function skip_name(),
because hash works faster and skip_name() spam each time in UI.