### PR TITLE
builder: set env var EU_INSTALL_ALWAYS_COPY for Makefile.PL

### DIFF
--- a/lib/Pakket/Builder/Perl.pm
+++ b/lib/Pakket/Builder/Perl.pm
@@ -17,6 +17,14 @@ sub build_package {
     $log->info("Building Perl module: $package");
 
     my %env  = generate_env_vars( $build_dir, $prefix );
+
+    # By default ExtUtils::Install checks if a file wasn't changed then skip it
+    # which breaks Builder::snapshot_build_dir().
+    # To change that behaviour and force installer to copy all files,
+    # ExtUtils::Install uses a parameter 'always_copy'
+    # or environment variable EU_INSTALL_ALWAYS_COPY.
+    $env{ 'EU_INSTALL_ALWAYS_COPY' } = 1;
+
     my $opts = { 'env' => \%env };
 
     foreach my $env_var ( keys %env ) {


### PR DESCRIPTION
This environment variable is used by ExtUtils::Install,
to force copy all files during 'make install'.
By default ExtUtils::Install checks if a file wasn't changed then skip it
which breaks our Builder::snapshot_build_dir() for some cases.
To change that behaviour ExtUtils::Install uses a parameter 'always_copy'
or environment variable EU_INSTALL_ALWAYS_COPY.
I didn't find a way how to pass that parameter 'always_copy'
through call 'perl Makefile.PL'.
Will define EU_INSTALL_ALWAYS_COPY then.