### PR TITLE
Handle errors from 'manage add'

### DIFF
--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -266,8 +266,11 @@ sub run {
         }
     }
 
-    for my $f ( keys %failed ) {
-        $log->infof( "[FAILED] %s: %s", $f, $failed{$f} );
+    if (scalar keys %failed) {
+        for my $f ( keys %failed ) {
+            $log->errorf( "[FAILED] %s: %s", $f, $failed{$f} );
+        }
+        exit 1;
     }
 
     $log->info( 'Done' );


### PR DESCRIPTION
When 'manage add' has errors:
- use log->error instead of log->info
- do exit(1) instead of normal exit with 'done'