### PR TITLE
Change text of error message

### DIFF
--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -697,7 +697,9 @@ sub get_release_info {
         };
     }
 
-    for my $v ( sort { version->parse($b) <=> version->parse($a) } @valid_versions ) {
+    @valid_versions = sort { version->parse($b) <=> version->parse($a) } @valid_versions;
+
+    for my $v ( @valid_versions ) {
         if ( $requirements->accepts_module($name => $v) ) {
             $version         = $v;
             $release_prereqs = $all_dist_releases{$v}{'prereqs'} || {};
@@ -706,7 +708,9 @@ sub get_release_info {
             last;
         }
     }
-    $version or Carp::croak("Cannot match release for $dist_name");
+    $version or Carp::croak("Cannot find a suitable version for $dist_name requirements: "
+                                . $requirements->requirements_for_module($name)
+                                . ", available: " . join(', ', @valid_versions));
 
     $version = $self->known_incorrect_version_fixes->{ $dist_name }
         if exists $self->known_incorrect_version_fixes->{ $dist_name };


### PR DESCRIPTION
Old message:
[FAILED] Kafka: Cannot match release for Data-HexDump-Range

New message:
[FAILED] Kafka: Cannot match release for Data-HexDump-Range
 requirements: 0.13, available: v0.12.57, v0.06.26, v0.04.13,
 v0.13.59, v0.03.10, v0.11.48, v0.04.16, v0.13.71, v0.06.24, v0.13.72,
 v0.09.40, v0.07.28, v0.06.18, 0.01_1, v0.10.45 at
 /home/dulanov/pakket/lib/Pakket/Manager.pm line 175.