### PR TITLE
Add Data-HexDump-Range in the list of known_incorrect_version_fixes

### DIFF
--- a/lib/Pakket/Scaffolder/Perl/Role/Borked.pm
+++ b/lib/Pakket/Scaffolder/Perl/Role/Borked.pm
@@ -28,6 +28,7 @@ has 'known_incorrect_version_fixes' => (
             'IO-Capture'        => '0.05',
             'Memoize-Memcached' => '0.04',
             'Statistics-Regression' => '0.53',
+            'Data-HexDump-Range' => 'v0.13.72',
         }
     },
 );


### PR DESCRIPTION
Data-HexDump-Range has letter 'v' in its version name.
Kafka requires Data-HexDump-Range without 'v'.