### PR TITLE
Change type of error message $log->info -> $log->error

### DIFF
--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -267,7 +267,7 @@ sub run {
     }
 
     for my $f ( keys %failed ) {
-        $log->infof( "[FAILED] %s: %s", $f, $failed{$f} );
+        $log->errorf( "[FAILED] %s: %s", $f, $failed{$f} );
     }
 
     $log->info( 'Done' );


### PR DESCRIPTION
For error message:
[FAILED] AnyEvent: Cannot match release for AnyEvent at
pakket/lib/Pakket/Manager.pm line 175.