### PR TITLE
Change error message

### DIFF
--- a/lib/Pakket/Repository/Backend/HTTP.pm
+++ b/lib/Pakket/Repository/Backend/HTTP.pm
@@ -121,7 +121,9 @@ sub store_location {
     );
 
     if ( !$response->{'success'} ) {
-        croak( $log->criticalf( 'Could not store location for id %s', $id ) );
+        croak( $log->criticalf(
+            'Could not store location for id %s, URL: %s, Status: %s, Reason: %s',
+            $id, $response->{'url'}, $response->{'status'}, $response->{'reason'}));
     }
 }
 


### PR DESCRIPTION
Old message:
 Could not store location for id perl/Kafka=1.04:1

New message:
 Could not store location for id perl/Kafka=1.04:1,
 URL: http://pakket.prod.booking.com:80/source/store/location?id=perl%2FKafka%3D1.04%3A1,
 Status: 413, Reason: Request Entity Too Large