### PR TITLE
Change text of error message

### DIFF
--- a/lib/Pakket/Manager.pm
+++ b/lib/Pakket/Manager.pm
@@ -252,7 +252,7 @@ sub _get_scaffolder {
     $self->category eq 'perl'
         and return $self->_gen_scaffolder_perl;
 
-    croak("failed to create a scaffolder\n");
+    croak("Scaffolder for category " . $self->category . " doesn't exist");
 }
 
 sub _gen_scaffolder_perl {


### PR DESCRIPTION
Old message:
  failed to create a scaffolder

New message:
  Scaffolder for category native doesn't exist