### PR TITLE
Remove 'v' from version for filename of archive

### DIFF
--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -611,7 +611,8 @@ sub get_release_info_local {
     my $prereqs;
     my $dist_name = $self->get_dist_name($name);
 
-    my $from_file = path( $self->cache_dir, $dist_name . '-' . $ver . '.tar.gz' );
+    my $fix_ver = $ver =~ s/^[v]//r;
+    my $from_file = path( $self->cache_dir, $dist_name . '-' . $fix_ver . '.tar.gz' );
     if ( $from_file->exists ) {
         my $target = Path::Tiny->tempdir();
         my $dir    = $self->unpack( $target, $from_file );


### PR DESCRIPTION
We are using CPAN::Meta::Requirements which automatically inserts 'v'
in the version. But this 'v' doesn't exists in the filename of archive
when using flag --is-local.

$ perl -MCPAN::Meta::Requirements -MData::Dumper -e
'my $m=CPAN::Meta::Requirements->new();
$m->add_minimum("Bookings::RPMCentral"=>"2.0.14");
print Dumper $m->as_string_hash'

$VAR1 = {
    'Bookings::RPMCentral' => 'v2.0.14'
};