### PR TITLE
Remove work dir if installation failed

### DIFF
--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -32,6 +32,12 @@ with qw<
     Pakket::Role::RunCommand
 >;
 
+has 'dirty' => (
+    'is'      => 'rw',
+    'isa'     => 'Bool',
+    'default' => sub {0},
+);
+
 has 'force' => (
     'is'      => 'ro',
     'isa'     => 'Bool',
@@ -43,6 +49,15 @@ has 'requirements' => (
     'isa'     => 'HashRef',
     'default' => sub { +{} },
 );
+
+sub DEMOLISH {
+    my ( $self, $is_global ) = @_;
+
+    return unless $self->dirty;
+
+    $self->work_dir->remove_tree( { 'safe' => 0 } );
+    $self->dirty(0);
+}
 
 sub install {
     my ( $self, @packages ) = @_;
@@ -61,6 +76,7 @@ sub install {
 
     my $installer_cache = {};
 
+    $self->dirty(1);
     foreach my $package (@packages) {
         $self->install_package(
             $package,
@@ -70,6 +86,7 @@ sub install {
     }
 
     $self->activate_work_dir;
+    $self->dirty(0);
 
     $log->infof(
         "Finished installing %d packages into $self->pakket_dir",


### PR DESCRIPTION
We keep track of a 'dirty' state for the installer, and set it to 1 when
we start installing, and to 0 when installation finishes successfully.
When the installer is being DEMOLISHed, we check the flag and remove the
work dir if the flag is dirty.