### PR TITLE
Refactoring in perl scaffolder

### DIFF
--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -174,7 +174,7 @@ sub bootstrap_build {
     my ( $self, $category ) = @_;
 
     my @dists =
-        $category eq 'perl' ? map { $_->[1] } @{ $self->perl_bootstrap_modules } :
+        $category eq 'perl' ? @{ $self->perl_bootstrap_modules } :
         # add more categories here
         ();
 

--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -68,7 +68,7 @@ sub execute {
     my $command = $self->{'command'};
 
     my $is_local = +{
-        map { $_ => 1, s/-/::/gr => 1 } @{ $self->{'opt'}{'is_local'} }
+        map { $_ => 1 } @{ $self->{'opt'}{'is_local'} }
     };
 
     my $manager = Pakket::Manager->new(

--- a/lib/Pakket/Manager.pm
+++ b/lib/Pakket/Manager.pm
@@ -4,6 +4,7 @@ package Pakket::Manager;
 use Moose;
 use Log::Any qw< $log >;
 use Carp     qw< croak >;
+use Safe::Isa;
 
 use Pakket::Log;
 use Pakket::Scaffolder::Perl;
@@ -272,11 +273,11 @@ sub _gen_scaffolder_perl {
     } else {
         my $name = $self->package->name;
         my $version = $self->package->version;
-        # hack to pass exact version in prereq syntax
-        defined $version
-            and !$self->is_local->{ $name }
-            and ref($self->package) eq 'Pakket::PackageQuery'
-            and $version =~ s/^/== /;
+        if (defined $version && $self->package->$_isa('Pakket::PackageQuery')) {
+            # hack to pass exact version in prereq syntax
+            # add '==' before number of version
+            $version =~ s/^/== /;
+        }
 
         $params{'module'}  = $name;
         $params{'version'} = $version;

--- a/lib/Pakket/Role/Perl/BootstrapModules.pm
+++ b/lib/Pakket/Role/Perl/BootstrapModules.pm
@@ -6,16 +6,15 @@ use Moose::Role;
 # hardcoded list of packages we have to build first
 # using core modules to break cyclic dependencies.
 # we have to maintain the order in order for packages to build
-# this list is an arrayref to maintain order, the elements
-# of the list are arrayref tuples of [ module_name, distribution_name ]
+# this list is an arrayref to maintain order
 has 'perl_bootstrap_modules' => (
     'is'      => 'ro',
     'isa'     => 'ArrayRef',
     'default' => sub {
         [
-            [ 'ExtUtils::MakeMaker'     => 'ExtUtils-MakeMaker' ],
-            [ 'Module::Build'           => 'Module-Build' ],
-            [ 'Module::Build::WithXSpp' => 'Module-Build-WithXSpp' ],
+            'ExtUtils-MakeMaker',
+            'Module-Build',
+            'Module-Build-WithXSpp',
         ]
     },
 );
@@ -34,8 +33,6 @@ __END__
 
 =head2 perl_bootstrap_modules
 
-An arrayref of arrayrefs, containing a module name and distribution
-name.
+An arrayref containing distribution names of bootstrap modules.
 
-It is used as a list of Perl modules to bootstrap. They are mapped from
-module to distribution for look up.
+It is used as a list of Perl modules to bootstrap.

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -535,22 +535,20 @@ sub get_dist_name {
     # fallback 3: check if name matches a distribution name
     if ( ! $dist_name ) {
         eval {
-            my $name = $module_name =~ s/::/-/rgsmx;
+            $dist_name = $module_name =~ s/::/-/rgsmx;
             my $url = $self->metacpan_api . '/release';
-            $log->debug("Requesting information about distribution $name ($url)");
+            $log->debug("Requesting information about distribution $dist_name ($url)");
             my $res = $self->ua->post( $url,
-                                       +{ 'content' => $self->get_is_dist_name_query($name) }
+                                       +{ 'content' => $self->get_is_dist_name_query($dist_name) }
                                    );
             $res->{'status'} == 200 or Carp::croak();
 
             my $res_body = decode_json $res->{'content'};
             $res_body->{'hits'}{'total'} > 0 or Carp::croak();
 
-            $dist_name = $name;
             1;
         } or do {
-            my $error = $@ || 'Zombie error';
-            Carp::croak("Cannot find module by name: '$module_name' ($error)");
+            $log->warn("Cannot find distribution for module $module_name. Trying to use $dist_name as fallback");
         };
     }
 

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -61,13 +61,6 @@ has 'modules' => (
     'isa' => 'HashRef',
 );
 
-has 'spec_index' => (
-    'is'      => 'ro',
-    'isa'     => 'HashRef',
-    'lazy'    => 1,
-    'builder' => '_build_spec_index',
-);
-
 has 'prereqs' => (
     'is'      => 'ro',
     'isa'     => 'CPAN::Meta::Prereqs',
@@ -155,17 +148,6 @@ sub _build_download_dir {
     return Path::Tiny->tempdir( 'CLEANUP' => 1 );
 }
 
-sub _build_spec_index {
-    my $self = shift;
-    my $spec_index = $self->spec_repo->all_object_ids;
-    my %spec_index;
-    for ( @{ $spec_index } ) {
-        m{^.*?/(.*)=(.*?)$};
-        $spec_index{$1}{$2} = 1;
-    }
-    return \%spec_index;
-}
-
 sub _build_cpan_02packages {
     my $self = shift;
     my ( $dir, $file );
@@ -226,12 +208,6 @@ sub run {
     # Bootstrap toolchain
     if ( !( $self->no_bootstrap or $self->no_deps ) ) {
         for my $module ( @{ $self->perl_bootstrap_modules } ) {
-            # TODO: check versions
-            if ( exists $self->spec_index->{$module} ) {
-                $log->debugf( 'Skipping %s (already have version: %s)',
-                              $module, $self->spec_index->{$module} );
-                next;
-            }
 
             $log->debugf( 'Bootstrapping config: %s', $module );
             my $requirements = $self->prereqs->requirements_for(qw< configure requires >);

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -285,7 +285,7 @@ sub skip_name {
         return 1;
     }
 
-    if ( exists $self->known_names_to_skip->{ $name } ) {
+    if ( exists $self->known_modules_to_skip->{ $name } ) {
         $log->debugf( "%sSkipping %s (known 'bad' name for configuration)", $self->spaces, $name );
         return 1;
     }

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -18,7 +18,7 @@ use Log::Any            qw< $log >;
 
 use Pakket::Package;
 use Pakket::Types;
-use Pakket::Utils::Perl qw< should_skip_module >;
+use Pakket::Utils::Perl qw< should_skip_core_module >;
 use Pakket::Constants   qw< PAKKET_PACKAGE_SPEC >;
 use Pakket::Scaffolder::Perl::Module;
 use Pakket::Scaffolder::Perl::CPANfile;
@@ -280,7 +280,7 @@ sub run {
 sub skip_name {
     my ( $self, $name ) = @_;
 
-    if ( should_skip_module($name) ) {
+    if ( should_skip_core_module($name) ) {
         $log->debugf( "%sSkipping %s (core module, not dual-life)", $self->spaces, $name );
         return 1;
     }

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -50,7 +50,7 @@ has 'phases' => (
     'required' => 1,
 );
 
-has 'processed_dists' => (
+has 'processed_packages' => (
     'is'      => 'ro',
     'isa'     => 'HashRef',
     'default' => sub { return +{} },
@@ -339,7 +339,7 @@ sub has_satisfying {
 sub create_spec_for {
     my ( $self, $name, $requirements ) = @_;
 
-    return if $self->processed_dists->{ $name }++;
+    return if $self->processed_packages->{ $name }++;
     return if $self->skip_name($name);
     return if $self->has_satisfying($name, $requirements);
 

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -225,7 +225,7 @@ sub run {
 
     # Bootstrap toolchain
     if ( !( $self->no_bootstrap or $self->no_deps ) ) {
-        for my $module ( map { $_->[0] } @{ $self->perl_bootstrap_modules } ) {
+        for my $module ( @{ $self->perl_bootstrap_modules } ) {
             # TODO: check versions
             if ( exists $self->spec_index->{$module} ) {
                 $log->debugf( 'Skipping %s (already have version: %s)',

--- a/lib/Pakket/Scaffolder/Perl/Role/Borked.pm
+++ b/lib/Pakket/Scaffolder/Perl/Role/Borked.pm
@@ -47,7 +47,7 @@ has 'known_incorrect_dependencies' => (
     },
 );
 
-has 'known_names_to_skip' => (
+has 'known_modules_to_skip' => (
     'is'      => 'ro',
     'isa'     => 'HashRef',
     'default' => sub {

--- a/lib/Pakket/Utils/Perl.pm
+++ b/lib/Pakket/Utils/Perl.pm
@@ -8,14 +8,14 @@ use Exporter   qw< import >;
 use Path::Tiny qw< path   >;
 use Module::CoreList;
 
-our @EXPORT_OK = qw< list_core_modules should_skip_module >;
+our @EXPORT_OK = qw< list_core_modules should_skip_core_module >;
 
 sub list_core_modules {
     ## no critic qw(Variables::ProhibitPackageVars)
     return \%Module::CoreList::upstream;
 }
 
-sub should_skip_module {
+sub should_skip_core_module {
     my $name = shift;
 
     if ( Module::CoreList::is_core($name) and !${Module::CoreList::upstream}{$name} ) {


### PR DESCRIPTION
There was a big mess between module_name and package_name.
Scaffolder called create_spec_for() sometimes with module name sometimes with package
name. Sometimes it translated names by calling MetaCPAN, sometimes
just by applying regex s/::/-/ forth and back.

Made using variables 'module_name' and 'package_name' accordance with its name.

Renamed create_spec_for() -> scaffold_package(). 
Split it into few functions to make the workflow more readable.

Added/changed many log messages.

Improved speed of scaffolding. For example:
$ time pakket manage add perl/Data-Visitor=0.26:1

old speed:
real    4m6.147s
user    0m18.986s
sys     0m2.143s

new speed:
real    1m54.033s
user    0m12.312s
sys     0m1.818s