### PR TITLE
Add native scaffolder

### DIFF
--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -43,6 +43,7 @@ sub opt_spec {
         [ 'is-local=s@',  'do not use upstream sources (i.e. CPAN) for given packages' ],
         [ 'requires-only', 'do not set recommended/suggested dependencies' ],
         [ 'no-bootstrap',  'skip bootstrapping phase (toolchain packages)' ],
+        [ 'source-archive=s', 'archve with sources (optional, only for native)' ],
     );
 }
 
@@ -82,6 +83,7 @@ sub execute {
         requires_only   => $self->{'opt'}{'requires_only'},
         no_bootstrap    => $self->{'opt'}{'no_bootstrap'},
         is_local        => $is_local,
+        source_archive  => $self->{'source_archive'},
     );
 
     if ( $command eq 'add' ) {
@@ -207,6 +209,7 @@ sub _validate_args_add {
     my $additional_phase = $self->{'opt'}{'additional_phase'};
 
     $self->{'file_02packages'} = $self->{'opt'}{'cpan_02packages'};
+    $self->{'source_archive'}  = $self->{'opt'}{'source_archive'};
 
     if ( $cpanfile ) {
         @{ $self->{'args'} }

--- a/lib/Pakket/Manager.pm
+++ b/lib/Pakket/Manager.pm
@@ -7,6 +7,7 @@ use Carp     qw< croak >;
 use Safe::Isa;
 
 use Pakket::Log;
+use Pakket::Scaffolder::Native;
 use Pakket::Scaffolder::Perl;
 
 has 'config' => (
@@ -68,6 +69,11 @@ has 'no_bootstrap' => (
     'is'        => 'ro',
     'isa'       => 'Bool',
     'default'   => 0,
+);
+
+has 'source_archive' => (
+    'is'        => 'ro',
+    'isa'       => 'Maybe[Str]',
 );
 
 sub _build_category {
@@ -252,6 +258,8 @@ sub _get_scaffolder {
 
     $self->category eq 'perl'
         and return $self->_gen_scaffolder_perl;
+    $self->category eq 'native'
+        and return $self->_gen_scaffolder_native;
 
     croak("Scaffolder for category " . $self->category . " doesn't exist");
 }
@@ -293,6 +301,21 @@ sub _gen_scaffolder_perl {
         and $params{'no_bootstrap'} = $self->no_bootstrap;
 
     return Pakket::Scaffolder::Perl->new(%params);
+}
+
+sub _gen_scaffolder_native {
+    my $self = shift;
+
+    my $name = $self->package->name;
+    my $version = $self->package->version;
+
+    my %params = (
+        'package'         => $self->package,
+        'source_archive'  => $self->source_archive,
+        'config'          => $self->config,
+    );
+
+    return Pakket::Scaffolder::Native->new(%params);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Pakket/Scaffolder/Native.pm
+++ b/lib/Pakket/Scaffolder/Native.pm
@@ -1,0 +1,102 @@
+package Pakket::Scaffolder::Native;
+# ABSTRACT: Scffolding Native distributions
+
+use Moose;
+use MooseX::StrictConstructor;
+use Path::Tiny          qw< path >;
+use Types::Path::Tiny   qw< Path  >;
+use Log::Any            qw< $log >;
+
+with qw<
+    Pakket::Role::HasConfig
+    Pakket::Role::HasSpecRepo
+    Pakket::Role::HasSourceRepo
+>;
+
+has 'package' => (
+    'is' => 'ro',
+);
+
+has 'source_archive' => (
+    'is'      => 'ro',
+    'isa'     => Path,
+    'coerce'  => 1,
+);
+
+sub run {
+    my $self = shift;
+
+    if ( $self->spec_repo->has_object( $self->package->id ) ) {
+        $log->debugf("Package %s already exists", $self->package->full_name);
+        return;
+    }
+
+    $log->infof('Working on %s', $self->package->full_name);
+
+    # Source
+    $self->add_source();
+
+    # Spec
+    $self->add_spec();
+
+    $log->infof('Done: %s', $self->package->full_name);
+}
+
+sub add_source {
+    my $self = shift;
+
+    if ($self->source_repo->has_object($self->package->id)) {
+        $log->debugf("Package %s already exists in source repo (skipping)",
+                        $self->package->full_name);
+        return;
+    }
+
+    if (!$self->source_archive->exists) {
+        Carp::croak("Archive with sources doesn't exist: ", $self->source_archive);
+    }
+
+    my $target = Path::Tiny->tempdir();
+    my $dir    = $self->unpack($target, $self->source_archive);
+
+    $log->debugf("Uploading %s into source repo from %s", $self->package->full_name, $dir);
+    $self->source_repo->store_package_source($self->package, $dir);
+}
+
+sub add_spec {
+    my $self = shift;
+
+    $log->debugf("Creating spec for %s", $self->package->full_name);
+
+    my $package = Pakket::Package->new(
+            'category' => $self->package->category,
+            'name'     => $self->package->name,
+            'version'  => $self->package->version,
+            'release'  => $self->package->release,
+        );
+
+    $self->spec_repo->store_package_spec($package);
+}
+
+sub unpack {
+    my ($self, $target, $file) = @_;
+
+    my $archive = Archive::Any->new($file);
+
+    if ($archive->is_naughty) {
+        Carp::croak($log->critical("Suspicious module ($file)"));
+    }
+
+    $archive->extract($target);
+
+    my @files = $target->children();
+    if (@files == 1 && $files[0]->is_dir) {
+        return $files[0];
+    }
+
+    return $target;
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+__END__


### PR DESCRIPTION
This is simple native scaffolder. It can add native package from
archive file with sources to spec and sources repositories.

Example:
$pakket manage add -vvv native/mariadb-connector-c=3.0.2:1
        --source-archive=~/mariadb-connector-c-3.0.2-src.tar.gz