### PR TITLE
Use build options and native dependencies from Pakket.json

### DIFF
--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -580,7 +580,7 @@ sub get_configure_flags {
 
     $config or return [];
 
-    my @flags = map +( join '=', $_, $config->{$_} ), keys %{$config};
+    my @flags = @{$config};
 
     $self->_expand_flags_inplace( \@flags, $expand_env );
 

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -758,8 +758,7 @@ sub get_release_query {
 
 # parsing Pakket.json
 # Packet.json should be in root directory of package, near META.json
-# We want to put there some pakket settings for packages.
-# Currently it keeps map 'module_to_distribution' for local non-CPAN dependencies.
+# It keeps some settings which we are missing in META.json.
 sub load_pakket_json {
     my ($self, $dir) = @_;
     my $pakket_json = $dir->child('Pakket.json');

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -766,6 +766,8 @@ sub load_pakket_json {
 
     $pakket_json->exists or return;
 
+    $log->debug("Found Pakket.json");
+
     my $data = decode_json($pakket_json->slurp_utf8);
 
     # Section 'module_to_distribution'

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -772,9 +772,11 @@ sub load_pakket_json {
 
     # Section 'module_to_distribution'
     # Using to map module->distribution for local not-CPAN modules
-    for my $module_name ( keys %{$data->{'module_to_distribution'}}  ) {
-        my $dist_name = $data->{'module_to_distribution'}{$module_name};
-        $self->dist_name->{$module_name} = $dist_name;
+    if ($data->{'module_to_distribution'}) {
+        for my $module_name ( keys %{$data->{'module_to_distribution'}}  ) {
+            my $dist_name = $data->{'module_to_distribution'}{$module_name};
+            $self->dist_name->{$module_name} = $dist_name;
+        }
     }
 }
 


### PR DESCRIPTION
This patch fixes MariaDB-NonBlocking. It allows to define some additional options via Pakket.json
```
Pakket.json
{
   "prereqs" : {
        "native" : {
            "configure" : {
                "mariadb-connector-c" : "0"
            }  
        }  
    }, 
    "build_opts" : {
        "configure_flags" : [
            "--static_link_to_mariadbclient"
        ]  
    }  
}
```